### PR TITLE
Removed HTML comment that should not have been in JS file

### DIFF
--- a/sites/all/themes/touchm/javascripts/app.js
+++ b/sites/all/themes/touchm/javascripts/app.js
@@ -101,7 +101,6 @@
 
 
 
-  <!-- Target sliders individually with different properties -->
   $(window).load(function() {
 	  
     $('.simple-slider').flexslider({


### PR DESCRIPTION
From my local testing, this HTML comment in a JS file appears to be the thing that's breaking the login form and menu on mobile devices, though that wouldn't explain why it suddenly started doing so. I was able to use the iOS simulator to find a parser error, and after copying the page source and JS locally, I could replicate it in Chrome. Removing that comment fixed it there, but I'm not able to re-test in mobile safari with my local dev setup. So, I'd like to get this on production for testing there.

Since this was a paid theme, I can't figure out if they might have released a bugfix version: there's no version number in the theme info file, not info on their website about release notes that I can find. I hate tweaking third party code, but it might be necessary in this case.

Fixes #48
