### PR TITLE
Override location field validation to force US for the country

### DIFF
--- a/sites/all/modules/chaos_misc/chaos_misc.info
+++ b/sites/all/modules/chaos_misc/chaos_misc.info
@@ -1,0 +1,4 @@
+name = CHAOS Misc
+description = Misc functionality
+core = 7.x
+package = CHAOS Brew Club

--- a/sites/all/modules/chaos_misc/chaos_misc.module
+++ b/sites/all/modules/chaos_misc/chaos_misc.module
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Implements hook_element_info_alter().
+ */
+function chaos_misc_element_info_alter(&$type) {
+  // Override the location field validation
+  if (isset($type['location_element']['#element_validate'])) {
+    // Remove the original validation
+    $existing_validation = array_search("location_element_validate", $type['location_element']['#element_validate']);
+    if (isset($existing_validation)) {
+      unset($type['location_element']['#element_validate'][$existing_validation]);
+    }
+
+    // Add our validation
+    $type['location_element']['#element_validate'][] = "chaos_misc_location_element_validate";
+  }
+}
+
+
+/**
+ * Override for location_element_validate
+ */
+function chaos_misc_location_element_validate($element, &$form_state) {
+  // If the province is set, force the country to US
+  dsm($element['province'], 'province');
+  dsm($element['country'], 'country');
+  if (!empty($element['province']) && !empty($element['province']['#value'])) {
+    $element['country']['#value'] = 'us';
+  }
+
+  // Then, call the exsiting validation
+  location_invoke_locationapi($element, 'validate');
+}


### PR DESCRIPTION
To address the "The specified province was not found in the specified country" validation error: if any province is set, force the country to the US. This fixes the problem where the country field was empty for some reason by strongarming it back into shape.

I'm going to go head and merge this so we can test it with real data on production, though I'm going to ask Jim for more particulars so I can try testing more locally.
